### PR TITLE
Notificaciones de Travis sólo en caso de errores

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ language: java
 sudo: true
 dist: trusty
 
+notifications:
+  email:
+    on_success: never # default: change
+    on_failure: always # default: always
+
 cache:
   directories:
     - "$HOME/.m2"


### PR DESCRIPTION
Desactivo las notificaciones para casos de build exitosos

Se supone que siempre debería ser exitoso 👀